### PR TITLE
Bump golang version / set to latest golang alpine image

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,2 +1,3 @@
 Jayden Chan <jaydencn7@gmail.com> (https://github.com/jayden-chan)
 HonestPretzels (https://github.com/HonestPretzels)
+NorskNoobing (https://github.com/NorskNoobing)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Puggies. If not, see <https://www.gnu.org/licenses/>.
 
-FROM golang:alpine3.20 as backendBuilder
+FROM golang:alpine as backendBuilder
 WORKDIR /workspace
 
 # we will grab the SSL certs and timezone data so people

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Puggies. If not, see <https://www.gnu.org/licenses/>.
 
-FROM golang:1.17.6-alpine as backendBuilder
+FROM golang:alpine3.20 as backendBuilder
 WORKDIR /workspace
 
 # we will grab the SSL certs and timezone data so people

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -4,7 +4,7 @@ Puggies is developed with Go, React and Docker. If you want to contribute to Pug
 will need the following tools installed on your computer:
 
 * [Git](https://git-scm.com/)
-* [Go](https://go.dev/)
+* [Go](https://go.dev/) (1.20+, only tested with 1.23.1)
 * [NodeJS LTS](https://nodejs.org/en/)
 * [Yarn](https://classic.yarnpkg.com/lang/en/)
 * [Docker](https://www.docker.com/)


### PR DESCRIPTION
## Description of the change
Sets the golang image in the `DOCKERFILE` to `golang:alpine`. This makes it so it always uses the latest golang alpine version, so the image building process won't break each time the golang package dependencies are updated.

## Type of change

- [ ] Refactoring (no change in functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Checklists

### Development

- [ ] [Prettier](https://www.npmjs.com/package/prettier) was run on frontend
- [ ] `go fmt` was run on backend

##### (if new config variable was added):
- [ ] Configuration documentation was updated 
- [ ] Docker Compose example file was updated (for required variables with no default)

##### (if new dependency was added):
- [x] New dependencies have been audited and are justified
- [x] Development documentation has been updated

##### (if database schema was updated):
- [ ] New database migrations have been generated with `migrate` tool
- [ ] Migrations have been tested in both directions (cleanly migrates up and down)

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] `AUTHORS.txt` was updated if there are new contributors (welcome!)

### Code review

- [ ] Security impacts of this change have been considered
